### PR TITLE
Basic (non-functional) [%eval] implementation

### DIFF
--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -265,7 +265,7 @@ let iter_on_occurrences
       | Texp_mutvar _ | Texp_setmutvar _
       | Texp_open _ | Texp_src_pos | Texp_overwrite _
       | Texp_hole _ | Texp_quotation _ | Texp_antiquotation _
-      | Texp_eval_quotation _ -> ());
+      | Texp_eval _ -> ());
       default_iterator.expr sub e);
 
   (* Remark: some types get iterated over twice due to how constraints are

--- a/file_formats/cmt_format.ml
+++ b/file_formats/cmt_format.ml
@@ -264,7 +264,8 @@ let iter_on_occurrences
       | Texp_probe_is_enabled _ | Texp_exclave _
       | Texp_mutvar _ | Texp_setmutvar _
       | Texp_open _ | Texp_src_pos | Texp_overwrite _
-      | Texp_hole _ | Texp_quotation _ | Texp_antiquotation _ -> ());
+      | Texp_hole _ | Texp_quotation _ | Texp_antiquotation _
+      | Texp_eval_quotation _ -> ());
       default_iterator.expr sub e);
 
   (* Remark: some types get iterated over twice due to how constraints are

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1335,6 +1335,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   (* TODO: update scopes *)
   | Texp_antiquotation _ ->
       failwith "Cannot unqoute outside of a quotation context."
+  | Texp_eval_quotation _ -> failwith "[%eval] is unimplemented"
 
 and pure_module m =
   match m.mod_desc with

--- a/lambda/translcore.ml
+++ b/lambda/translcore.ml
@@ -1335,7 +1335,7 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
   (* TODO: update scopes *)
   | Texp_antiquotation _ ->
       failwith "Cannot unqoute outside of a quotation context."
-  | Texp_eval_quotation (_, sort) ->
+  | Texp_eval (_, sort) ->
       let loc = of_location ~scopes e.exp_loc in
       let quote_ident = Ident.create_local "quote" in
       let ret_sort = Jkind.Sort.default_for_transl_and_get sort in
@@ -1371,12 +1371,6 @@ and transl_exp0 ~in_new_scope ~scopes sort e =
             layout = layout_block;
             attributes = default_param_attribute;
             mode = alloc_local;
-          };
-          { name = Ident.create_local "unit";
-            debug_uid = debug_uid_none;
-            layout = layout_unit;
-            attributes = default_param_attribute;
-            mode = alloc_heap;
           };
         ]
         ~return:result_layout

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -1753,7 +1753,7 @@ and Exp_desc : sig
 
   val splice : Location.t -> Code.t -> t'
 
-  val eval_quote : Location.t -> Type.t -> t'
+  val eval : Location.t -> Type.t -> t'
 end = struct
   type s = lambda
 
@@ -1894,7 +1894,7 @@ end = struct
 
   let splice loc a1 = apply1 "Exp_desc" "splice" loc (extract a1)
 
-  let eval_quote loc a1 = apply1 "Exp_desc" "eval_quote" loc (extract a1)
+  let eval loc a1 = apply1 "Exp_desc" "eval" loc (extract a1)
 end
 
 and Exp : sig
@@ -3061,8 +3061,7 @@ and quote_expression_desc transl stage e =
     | Texp_atomic_loc _ ->
       fatal_error "Cannot quote Texp_atomic_loc constructs yet."
     | Texp_idx _ -> fatal_error "Cannot quote Texp_idx constructs yet."
-    | Texp_eval_quotation (typ, _) ->
-      Exp_desc.eval_quote loc (quote_core_type typ)
+    | Texp_eval (typ, _) -> Exp_desc.eval loc (quote_core_type typ)
   in
   List.iter update_env_without_extra e.exp_extra;
   List.fold_right

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -3061,7 +3061,7 @@ and quote_expression_desc transl stage e =
     | Texp_atomic_loc _ ->
       fatal_error "Cannot quote Texp_atomic_loc constructs yet."
     | Texp_idx _ -> fatal_error "Cannot quote Texp_idx constructs yet."
-    | Texp_eval_quotation typ ->
+    | Texp_eval_quotation (typ, _) ->
       Exp_desc.eval_quote loc (quote_core_type ~in_constraint:true typ)
   in
   List.iter update_env_without_extra e.exp_extra;

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -1752,6 +1752,8 @@ and Exp_desc : sig
   val antiquote : Location.t -> Exp.t -> t'
 
   val splice : Location.t -> Code.t -> t'
+
+  val eval_quote : Location.t -> Type.t -> t'
 end = struct
   type s = lambda
 
@@ -1891,6 +1893,8 @@ end = struct
   let antiquote loc a1 = apply1 "Exp_desc" "antiquote" loc (extract a1)
 
   let splice loc a1 = apply1 "Exp_desc" "splice" loc (extract a1)
+
+  let eval_quote loc a1 = apply1 "Exp_desc" "eval_quote" loc (extract a1)
 end
 
 and Exp : sig
@@ -3057,6 +3061,8 @@ and quote_expression_desc transl stage e =
     | Texp_atomic_loc _ ->
       fatal_error "Cannot quote Texp_atomic_loc constructs yet."
     | Texp_idx _ -> fatal_error "Cannot quote Texp_idx constructs yet."
+    | Texp_eval_quotation typ ->
+      Exp_desc.eval_quote loc (quote_core_type ~in_constraint:true typ)
   in
   List.iter update_env_without_extra e.exp_extra;
   List.fold_right

--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -3062,7 +3062,7 @@ and quote_expression_desc transl stage e =
       fatal_error "Cannot quote Texp_atomic_loc constructs yet."
     | Texp_idx _ -> fatal_error "Cannot quote Texp_idx constructs yet."
     | Texp_eval_quotation (typ, _) ->
-      Exp_desc.eval_quote loc (quote_core_type ~in_constraint:true typ)
+      Exp_desc.eval_quote loc (quote_core_type typ)
   in
   List.iter update_env_without_extra e.exp_extra;
   List.fold_right

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -1118,4 +1118,9 @@ let get_tracing_probe_payload (payload : Parsetree.payload) =
   in
   Ok { name; name_loc; enabled_at_init; arg }
 
+let get_eval_quote_payload payload =
+  match payload with
+  | PTyp typ -> Ok typ
+  | _ -> Error ()
+
 let has_atomic attrs = has_attribute "atomic" attrs

--- a/parsing/builtin_attributes.ml
+++ b/parsing/builtin_attributes.ml
@@ -1118,7 +1118,7 @@ let get_tracing_probe_payload (payload : Parsetree.payload) =
   in
   Ok { name; name_loc; enabled_at_init; arg }
 
-let get_eval_quote_payload payload =
+let get_eval_payload payload =
   match payload with
   | PTyp typ -> Ok typ
   | _ -> Error ()

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -346,9 +346,9 @@ type tracing_probe =
 val get_tracing_probe_payload :
   Parsetree.payload -> (tracing_probe, unit) result
 
-(* Gets the payload of a [eval] extension node which evaluates quotes, for example:
-   [%eval: int] *)
-val get_eval_quote_payload :
+(* Gets the payload of a [eval] extension node which evaluates quotes,
+   for example: [%eval: int] *)
+val get_eval_payload :
   Parsetree.payload -> (Parsetree.core_type, unit) result
 
 val has_atomic: Parsetree.attributes -> bool

--- a/parsing/builtin_attributes.mli
+++ b/parsing/builtin_attributes.mli
@@ -346,4 +346,9 @@ type tracing_probe =
 val get_tracing_probe_payload :
   Parsetree.payload -> (tracing_probe, unit) result
 
+(* Gets the payload of a [eval] extension node which evaluates quotes, for example:
+   [%eval: int] *)
+val get_eval_quote_payload :
+  Parsetree.payload -> (Parsetree.core_type, unit) result
+
 val has_atomic: Parsetree.attributes -> bool

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1280,6 +1280,7 @@ module Ast = struct
     | Array_comprehension of comprehension
     | Quote of expression
     | Antiquote of expression
+    | Eval_quote of core_type
 
   and case =
     { lhs : pattern;
@@ -1860,6 +1861,7 @@ module Ast = struct
     | Antiquote exp -> pp fmt "@[<2>$@,%a@]" (print_exp_with_parens env) exp
     | List_comprehension _ | Array_comprehension _ ->
       pp fmt "(* comprehension *)"
+    | Eval_quote typ -> pp fmt "@[<2>[%%eval:@ %a]@]" (print_core_type env) typ
     | Unreachable | Src_pos -> pp fmt "."
 
   and print_exp env fmt exp =
@@ -2749,6 +2751,10 @@ module Exp_desc = struct
   let splice code =
     let+ exp = Code.to_exp code in
     Ast.(exp.desc)
+
+  let eval_quote typ =
+    let+ typ = typ in
+    Ast.Eval_quote typ
 end
 
 module Exp = struct

--- a/stdlib/camlinternalQuote.ml
+++ b/stdlib/camlinternalQuote.ml
@@ -1280,7 +1280,7 @@ module Ast = struct
     | Array_comprehension of comprehension
     | Quote of expression
     | Antiquote of expression
-    | Eval_quote of core_type
+    | Eval of core_type
 
   and case =
     { lhs : pattern;
@@ -1861,7 +1861,7 @@ module Ast = struct
     | Antiquote exp -> pp fmt "@[<2>$@,%a@]" (print_exp_with_parens env) exp
     | List_comprehension _ | Array_comprehension _ ->
       pp fmt "(* comprehension *)"
-    | Eval_quote typ -> pp fmt "@[<2>[%%eval:@ %a]@]" (print_core_type env) typ
+    | Eval typ -> pp fmt "@[<2>[%%eval:@ %a]@]" (print_core_type env) typ
     | Unreachable | Src_pos -> pp fmt "."
 
   and print_exp env fmt exp =
@@ -2752,9 +2752,9 @@ module Exp_desc = struct
     let+ exp = Code.to_exp code in
     Ast.(exp.desc)
 
-  let eval_quote typ =
+  let eval typ =
     let+ typ = typ in
-    Ast.Eval_quote typ
+    Ast.Eval typ
 end
 
 module Exp = struct

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -596,7 +596,7 @@ and Exp_desc : sig
 
   val splice : Code.t -> t
 
-  val eval_quote : Type.t -> t
+  val eval : Type.t -> t
 end
 
 and Exp : sig

--- a/stdlib/camlinternalQuote.mli
+++ b/stdlib/camlinternalQuote.mli
@@ -595,6 +595,8 @@ and Exp_desc : sig
   val antiquote : Exp.t -> t
 
   val splice : Code.t -> t
+
+  val eval_quote : Type.t -> t
 end
 
 and Exp : sig

--- a/testsuite/tests/quotation/quotation_eval.ml
+++ b/testsuite/tests/quotation/quotation_eval.ml
@@ -1,0 +1,54 @@
+(* TEST
+ expect;
+*)
+
+let a0 = [%eval: int];;
+let b0 = a0 <[ 1 ]>;;
+let c0 = b0 ();;
+
+[%%expect{|
+val a0 : <[ int ]> expr -> unit -> int = <fun>
+val b0 : unit -> int = <fun>
+Exception: Invalid_argument "1".
+|}]
+
+let a1 = [%eval: int -> int list];;
+let b1 = a1 <[ fun x -> [ x ; x + 1 ] ]>;;
+let c1 = b1 ();;
+let d1 = c1 42;;
+
+[%%expect{|
+val a1 : <[ int -> int list ]> expr -> unit -> int -> int list = <fun>
+val b1 : unit -> int -> int list = <fun>
+Exception: Invalid_argument "fun x -> (::) (x, ((::) ((x + 1), [])))".
+|}]
+
+let a2 = [%eval: Buffer.t]
+let b2 = a2 <[ Buffer.create 42 ]>;;
+let c2 = b2 ();;
+
+[%%expect{|
+val a2 : <[ Buffer.t ]> expr -> unit -> Buffer.t = <fun>
+val b2 : unit -> Buffer.t = <fun>
+Exception: Invalid_argument "Stdlib.Buffer.create 42".
+|}]
+
+let a3 = [%eval: unit]
+(* This quote passes type-checking but fail during compilation, this lets us test exactly
+   when compilation of the quote happens (and what happens when it fails). *)
+let b3 = a3 <[
+    let ignore (_ @ local) = () in
+    let[@tail_mod_cons] rec foo x = exclave_
+      if x = 0 then [] else x :: foo (x - 1)
+    in
+    ignore (foo 5)
+  ]>;;
+let c3 = b3 ();;
+
+[%%expect{|
+val a3 : <[ unit ]> expr -> unit -> unit = <fun>
+val b3 : unit -> unit = <fun>
+Exception:
+Invalid_argument
+ "let ignore = (fun _ -> ()) in\nlet rec foo =\n(fun x -> exclave_ if (x = 0) then [] else (::) (x, (foo (x - 1)))) in\nignore (foo 5)".
+|}]

--- a/testsuite/tests/quotation/quotation_eval.ml
+++ b/testsuite/tests/quotation/quotation_eval.ml
@@ -4,32 +4,26 @@
 
 let a0 = [%eval: int];;
 let b0 = a0 <[ 1 ]>;;
-let c0 = b0 ();;
 
 [%%expect{|
-val a0 : <[ int ]> expr -> unit -> int = <fun>
-val b0 : unit -> int = <fun>
+val a0 : <[ int ]> expr -> int = <fun>
 Exception: Invalid_argument "1".
 |}]
 
 let a1 = [%eval: int -> int list];;
 let b1 = a1 <[ fun x -> [ x ; x + 1 ] ]>;;
-let c1 = b1 ();;
-let d1 = c1 42;;
+let c1 = b1 42;;
 
 [%%expect{|
-val a1 : <[ int -> int list ]> expr -> unit -> int -> int list = <fun>
-val b1 : unit -> int -> int list = <fun>
+val a1 : <[ int -> int list ]> expr -> int -> int list = <fun>
 Exception: Invalid_argument "fun x -> (::) (x, ((::) ((x + 1), [])))".
 |}]
 
 let a2 = [%eval: Buffer.t]
 let b2 = a2 <[ Buffer.create 42 ]>;;
-let c2 = b2 ();;
 
 [%%expect{|
-val a2 : <[ Buffer.t ]> expr -> unit -> Buffer.t = <fun>
-val b2 : unit -> Buffer.t = <fun>
+val a2 : <[ Buffer.t ]> expr -> Buffer.t = <fun>
 Exception: Invalid_argument "Stdlib.Buffer.create 42".
 |}]
 
@@ -43,11 +37,9 @@ let b3 = a3 <[
     in
     ignore (foo 5)
   ]>;;
-let c3 = b3 ();;
 
 [%%expect{|
-val a3 : <[ unit ]> expr -> unit -> unit = <fun>
-val b3 : unit -> unit = <fun>
+val a3 : <[ unit ]> expr -> unit = <fun>
 Exception:
 Invalid_argument
  "let ignore = (fun _ -> ()) in\nlet rec foo =\n(fun x -> exclave_ if (x = 0) then [] else (::) (x, (foo (x - 1)))) in\nignore (foo 5)".

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -720,8 +720,8 @@ and expression i ppf x =
   | Texp_antiquotation e ->
     line i ppf "Texp_antiquotation";
     expression i ppf e
-  | Texp_eval_quotation (typ, _) ->
-    line i ppf "Texp_eval_quotation ";
+  | Texp_eval (typ, _) ->
+    line i ppf "Texp_eval ";
     core_type i ppf typ;
 
 and value_description i ppf x =

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -720,7 +720,7 @@ and expression i ppf x =
   | Texp_antiquotation e ->
     line i ppf "Texp_antiquotation";
     expression i ppf e
-  | Texp_eval_quotation typ ->
+  | Texp_eval_quotation (typ, _) ->
     line i ppf "Texp_eval_quotation ";
     core_type i ppf typ;
 

--- a/typing/printtyped.ml
+++ b/typing/printtyped.ml
@@ -720,6 +720,9 @@ and expression i ppf x =
   | Texp_antiquotation e ->
     line i ppf "Texp_antiquotation";
     expression i ppf e
+  | Texp_eval_quotation typ ->
+    line i ppf "Texp_eval_quotation ";
+    core_type i ppf typ;
 
 and value_description i ppf x =
   line i ppf "value_description %a %a\n" fmt_ident x.val_id fmt_location

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -475,6 +475,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_hole _ -> ()
   | Texp_quotation exp -> sub.expr sub exp
   | Texp_antiquotation exp -> sub.expr sub exp
+  | Texp_eval_quotation typ -> sub.typ sub typ
 
 let package_type sub {pack_fields; pack_txt; _} =
   List.iter (fun (lid, p) -> iter_loc sub lid; sub.typ sub p) pack_fields;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -475,7 +475,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_hole _ -> ()
   | Texp_quotation exp -> sub.expr sub exp
   | Texp_antiquotation exp -> sub.expr sub exp
-  | Texp_eval_quotation (typ, _) -> sub.typ sub typ
+  | Texp_eval (typ, _) -> sub.typ sub typ
 
 let package_type sub {pack_fields; pack_txt; _} =
   List.iter (fun (lid, p) -> iter_loc sub lid; sub.typ sub p) pack_fields;

--- a/typing/tast_iterator.ml
+++ b/typing/tast_iterator.ml
@@ -475,7 +475,7 @@ let expr sub {exp_loc; exp_extra; exp_desc; exp_env; exp_attributes; _} =
   | Texp_hole _ -> ()
   | Texp_quotation exp -> sub.expr sub exp
   | Texp_antiquotation exp -> sub.expr sub exp
-  | Texp_eval_quotation typ -> sub.typ sub typ
+  | Texp_eval_quotation (typ, _) -> sub.typ sub typ
 
 let package_type sub {pack_fields; pack_txt; _} =
   List.iter (fun (lid, p) -> iter_loc sub lid; sub.typ sub p) pack_fields;

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -665,7 +665,7 @@ let expr sub x =
     | Texp_antiquotation exp ->
         Texp_antiquotation (sub.expr sub exp)
     | Texp_eval_quotation (typ, sort) ->
-      Texp_eval_quotation (sub.typ sub typ, sort)
+        Texp_eval_quotation (sub.typ sub typ, sort)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -664,8 +664,8 @@ let expr sub x =
         Texp_quotation (sub.expr sub exp)
     | Texp_antiquotation exp ->
         Texp_antiquotation (sub.expr sub exp)
-    | Texp_eval_quotation (typ, sort) ->
-        Texp_eval_quotation (sub.typ sub typ, sort)
+    | Texp_eval (typ, sort) ->
+        Texp_eval (sub.typ sub typ, sort)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -664,8 +664,8 @@ let expr sub x =
         Texp_quotation (sub.expr sub exp)
     | Texp_antiquotation exp ->
         Texp_antiquotation (sub.expr sub exp)
-    | Texp_eval_quotation typ ->
-      Texp_eval_quotation (sub.typ sub typ)
+    | Texp_eval_quotation (typ, sort) ->
+      Texp_eval_quotation (sub.typ sub typ, sort)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/tast_mapper.ml
+++ b/typing/tast_mapper.ml
@@ -664,6 +664,8 @@ let expr sub x =
         Texp_quotation (sub.expr sub exp)
     | Texp_antiquotation exp ->
         Texp_antiquotation (sub.expr sub exp)
+    | Texp_eval_quotation typ ->
+      Texp_eval_quotation (sub.typ sub typ)
   in
   let exp_attributes = sub.attributes sub x.exp_attributes in
   {x with exp_loc; exp_extra; exp_desc; exp_env; exp_attributes}

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7255,6 +7255,10 @@ and type_expect_
     | Error () -> raise (Error (loc, env, Eval_quote_format))
     | Ok typ ->
       let typ = Typetexp.transl_simple_type env ~new_var_jkind:Any ~closed:true Alloc.Const.legacy typ in
+      let sort = match type_sort ~why:Function_result ~fixed:false env typ.ctyp_type with
+      | Ok sort -> sort
+      | Error err -> raise (Error (loc, env, Function_type_not_rep (typ.ctyp_type, err)))
+      in
       let eval_type = newty
         (Tarrow
           ((Nolabel, Alloc.legacy, Alloc.legacy)
@@ -7267,7 +7271,7 @@ and type_expect_
           , commu_ok))
       in
       rue {
-        exp_desc = Texp_eval_quotation typ;
+        exp_desc = Texp_eval_quotation (typ, sort);
         exp_loc = loc; exp_extra = [];
         exp_type = eval_type;
         exp_attributes = sexp.pexp_attributes;

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -7254,14 +7254,14 @@ and type_expect_
     begin match Builtin_attributes.get_eval_quote_payload payload with
     | Error () -> raise (Error (loc, env, Eval_quote_format))
     | Ok typ ->
-      let typ = Typetexp.transl_simple_type_univars env typ in
+      let typ = Typetexp.transl_simple_type env ~new_var_jkind:Any ~closed:true Alloc.Const.legacy typ in
       let eval_type = newty
         (Tarrow
           ((Nolabel, Alloc.legacy, Alloc.legacy)
-          , Predef.type_code (newty (Tquote typ.ctyp_type))
+          , newmono (Predef.type_code (newgenty (Tquote typ.ctyp_type)))
           , newty(Tarrow
             ((Nolabel, Alloc.legacy, Alloc.legacy)
-            , Predef.type_unit
+            , newmono Predef.type_unit
             , typ.ctyp_type
             , commu_ok))
           , commu_ok))

--- a/typing/typecore.ml
+++ b/typing/typecore.ml
@@ -11822,8 +11822,8 @@ let report_error ~loc env =
         "This quotation construct is not presently supported."
   | Eval_quote_format ->
       Location.errorf ~loc
-        "The eval extension takes a single type as its argument, \
-         for example [%%eval: int]."
+        "The eval extension takes a single type as its argument, for example %a."
+         Style.inline_code "[%eval: int]"
 
 let report_error ~loc env err =
   Printtyp.wrap_printing_env_error env

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -346,7 +346,7 @@ type error =
   | Quotation_object
   | Open_inside_quotation
   | Unsupported_quotation_construct
-  | Eval_quote_format
+  | Eval_format
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/typecore.mli
+++ b/typing/typecore.mli
@@ -346,6 +346,7 @@ type error =
   | Quotation_object
   | Open_inside_quotation
   | Unsupported_quotation_construct
+  | Eval_quote_format
 
 exception Error of Location.t * Env.t * error
 exception Error_forward of Location.error

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -320,7 +320,7 @@ and expression_desc =
   | Texp_hole of unique_use
   | Texp_quotation of expression
   | Texp_antiquotation of expression
-  | Texp_eval_quotation of core_type
+  | Texp_eval_quotation of core_type * Jkind.sort
 
 and ident_kind =
   | Id_value

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -320,7 +320,7 @@ and expression_desc =
   | Texp_hole of unique_use
   | Texp_quotation of expression
   | Texp_antiquotation of expression
-  | Texp_eval_quotation of core_type * Jkind.sort
+  | Texp_eval of core_type * Jkind.sort
 
 and ident_kind =
   | Id_value
@@ -1474,7 +1474,7 @@ let rec fold_antiquote_exp f  acc exp =
   | Texp_quotation exp ->
       fold_antiquote_exp (fold_antiquote_exp f) acc exp
   | Texp_antiquotation exp -> f acc exp
-  | Texp_eval_quotation _ -> acc
+  | Texp_eval _ -> acc
 
 and fold_antiquote_exp_opt f acc = function
   | None -> acc

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -320,6 +320,7 @@ and expression_desc =
   | Texp_hole of unique_use
   | Texp_quotation of expression
   | Texp_antiquotation of expression
+  | Texp_eval_quotation of core_type
 
 and ident_kind =
   | Id_value
@@ -1473,6 +1474,7 @@ let rec fold_antiquote_exp f  acc exp =
   | Texp_quotation exp ->
       fold_antiquote_exp (fold_antiquote_exp f) acc exp
   | Texp_antiquotation exp -> f acc exp
+  | Texp_eval_quotation _ -> acc
 
 and fold_antiquote_exp_opt f acc = function
   | None -> acc

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -529,6 +529,7 @@ and expression_desc =
   | Texp_hole of unique_use (** _ *)
   | Texp_quotation of expression
   | Texp_antiquotation of expression
+  | Texp_eval_quotation of core_type
 
 and function_curry =
   | More_args of { partial_mode : Mode.Alloc.l }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -529,7 +529,7 @@ and expression_desc =
   | Texp_hole of unique_use (** _ *)
   | Texp_quotation of expression
   | Texp_antiquotation of expression
-  | Texp_eval_quotation of core_type * Jkind.sort
+  | Texp_eval of core_type * Jkind.sort
 
 and function_curry =
   | More_args of { partial_mode : Mode.Alloc.l }

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -529,7 +529,7 @@ and expression_desc =
   | Texp_hole of unique_use (** _ *)
   | Texp_quotation of expression
   | Texp_antiquotation of expression
-  | Texp_eval_quotation of core_type
+  | Texp_eval_quotation of core_type * Jkind.sort
 
 and function_curry =
   | More_args of { partial_mode : Mode.Alloc.l }

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2530,7 +2530,7 @@ let rec check_uniqueness_exp ~overwrite (ienv : Ienv.t) exp : UF.t =
   | Texp_antiquotation e ->
     let uf = check_uniqueness_exp ~overwrite:None ienv e in
     UF.antiquote uf
-  | Texp_eval_quotation _ -> UF.unused
+  | Texp_eval _ -> UF.unused
 
 (**
 Corresponds to the first mode.

--- a/typing/uniqueness_analysis.ml
+++ b/typing/uniqueness_analysis.ml
@@ -2530,6 +2530,7 @@ let rec check_uniqueness_exp ~overwrite (ienv : Ienv.t) exp : UF.t =
   | Texp_antiquotation e ->
     let uf = check_uniqueness_exp ~overwrite:None ienv e in
     UF.antiquote uf
+  | Texp_eval_quotation _ -> UF.unused
 
 (**
 Corresponds to the first mode.

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -758,7 +758,7 @@ let expression sub exp =
     | Texp_hole _ -> Pexp_hole
     | Texp_quotation exp -> Pexp_quotation (sub.expr sub exp)
     | Texp_antiquotation exp -> Pexp_splice (sub.expr sub exp)
-    | Texp_eval_quotation (typ, _) ->
+    | Texp_eval (typ, _) ->
         Pexp_extension ({ txt = "ocaml.eval"; loc}, PTyp (sub.typ sub typ))
   in
   List.fold_right (exp_extra sub) exp.exp_extra

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -758,7 +758,7 @@ let expression sub exp =
     | Texp_hole _ -> Pexp_hole
     | Texp_quotation exp -> Pexp_quotation (sub.expr sub exp)
     | Texp_antiquotation exp -> Pexp_splice (sub.expr sub exp)
-    | Texp_eval_quotation typ ->
+    | Texp_eval_quotation (typ, _) ->
         Pexp_extension ({ txt = "ocaml.eval"; loc}, PTyp (sub.typ sub typ))
   in
   List.fold_right (exp_extra sub) exp.exp_extra

--- a/typing/untypeast.ml
+++ b/typing/untypeast.ml
@@ -758,6 +758,8 @@ let expression sub exp =
     | Texp_hole _ -> Pexp_hole
     | Texp_quotation exp -> Pexp_quotation (sub.expr sub exp)
     | Texp_antiquotation exp -> Pexp_splice (sub.expr sub exp)
+    | Texp_eval_quotation typ ->
+        Pexp_extension ({ txt = "ocaml.eval"; loc}, PTyp (sub.typ sub typ))
   in
   List.fold_right (exp_extra sub) exp.exp_extra
     (Exp.mk ~loc ~attrs desc)

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -259,6 +259,7 @@ let classify_expression : Typedtree.expression -> sd =
           (* other cases compile to a lazy block holding a function *)
           Static
       end
+    | Texp_eval_quotation _ -> Static
 
     | Texp_new _
     | Texp_instvar _
@@ -1093,6 +1094,7 @@ let rec expression : Typedtree.expression -> term_judg =
         expression e << Dereference
     | Texp_antiquotation e ->
         expression e << Dereference
+    | Texp_eval_quotation _ -> empty
 
 (* Function bodies.
     G |-{body} b : m

--- a/typing/value_rec_check.ml
+++ b/typing/value_rec_check.ml
@@ -259,7 +259,7 @@ let classify_expression : Typedtree.expression -> sd =
           (* other cases compile to a lazy block holding a function *)
           Static
       end
-    | Texp_eval_quotation _ -> Static
+    | Texp_eval _ -> Static
 
     | Texp_new _
     | Texp_instvar _
@@ -1094,7 +1094,7 @@ let rec expression : Typedtree.expression -> term_judg =
         expression e << Dereference
     | Texp_antiquotation e ->
         expression e << Dereference
-    | Texp_eval_quotation _ -> empty
+    | Texp_eval _ -> empty
 
 (* Function bodies.
     G |-{body} b : m


### PR DESCRIPTION
This adds processing of `[%eval: <type>]` treating it as a function of type `<[ t ]> expr -> unit -> t`. The lambda it generates is intentially hokey, it just raises the quote printed as a string in an Invalid_argument exception. Doing something more reasonable will be addressed in (many) follow-up PRs. I haven't added any tests yet, I'll add them in a later PR when it can test the full end-to-end flow.