### PR TITLE
Fix constructor logic when generating lambda for quotations

### DIFF
--- a/lambda/translquote.ml
+++ b/lambda/translquote.ml
@@ -2554,40 +2554,49 @@ let quote_constructor env loc constr =
   let exception Non_builtin of string in
   (try
      Identifier.Constructor.wrap
-       (match type_path env constr.cstr_res with
-       | None ->
-         fatal_errorf "Translquote [at %a]: no global path for constructor"
-           Location.print_loc (to_location loc)
-       | Some (Path.Pident _) -> (
-         match constr.cstr_name with
-         | "false" -> Identifier.Constructor.false_
-         | "true" -> Identifier.Constructor.true_
-         | "()" -> Identifier.Constructor.void
-         | "[]" -> Identifier.Constructor.nil
-         | "::" -> Identifier.Constructor.cons
-         | "None" -> Identifier.Constructor.none
-         | "Some" -> Identifier.Constructor.some
-         | "Match_failure" -> Identifier.Constructor.match_failure
-         | "Out_of_memory" -> Identifier.Constructor.out_of_memory
-         | "Out_of_fibers" -> Identifier.Constructor.out_of_fibers
-         | "Invalid_argument" -> Identifier.Constructor.invalid_argument
-         | "Failure" -> Identifier.Constructor.failure
-         | "Not_found" -> Identifier.Constructor.not_found
-         | "Sys_error" -> Identifier.Constructor.sys_error
-         | "End_of_file" -> Identifier.Constructor.end_of_file
-         | "Division_by_zero" -> Identifier.Constructor.division_by_zero
-         | "Stack_overflow" -> Identifier.Constructor.stack_overflow
-         | "Sys_blocked_io" -> Identifier.Constructor.sys_blocked_io
-         | "Assert_failure" -> Identifier.Constructor.assert_failure
-         | "Undefined_recursive_module" ->
-           Identifier.Constructor.undefined_recursive_module
-         | name -> raise (Non_builtin name))
-       | Some (Path.Pdot (p, _)) ->
-         Identifier.Constructor.dot loc (module_for_path loc p) constr.cstr_name
-       | _ ->
-         fatal_errorf
-           "Translquote [at %a]: unsupported constructor type detected."
-           Location.print_loc (to_location loc))
+       (match constr.cstr_tag with
+        | Extension (Path.Pdot (p, name)) ->
+          Identifier.Constructor.dot loc (module_for_path loc p) name
+        | Extension (Path.Pident name) -> raise (Non_builtin (Ident.name name))
+        | Extension _ ->
+          fatal_errorf "Translquote [at %a]: Papply in extension constructor."
+            Location.print_loc (to_location loc)
+        | Ordinary _ | Null ->
+          (match type_path env constr.cstr_res with
+           | None ->
+             fatal_errorf "Translquote [at %a]: no global path for constructor"
+               Location.print_loc (to_location loc)
+           | Some (Path.Pident _) -> (
+               match constr.cstr_name with
+               | "false" -> Identifier.Constructor.false_
+               | "true" -> Identifier.Constructor.true_
+               | "()" -> Identifier.Constructor.void
+               | "[]" -> Identifier.Constructor.nil
+               | "::" -> Identifier.Constructor.cons
+               | "None" -> Identifier.Constructor.none
+               | "Some" -> Identifier.Constructor.some
+               | "Match_failure" -> Identifier.Constructor.match_failure
+               | "Out_of_memory" -> Identifier.Constructor.out_of_memory
+               | "Out_of_fibers" -> Identifier.Constructor.out_of_fibers
+               | "Invalid_argument" -> Identifier.Constructor.invalid_argument
+               | "Failure" -> Identifier.Constructor.failure
+               | "Not_found" -> Identifier.Constructor.not_found
+               | "Sys_error" -> Identifier.Constructor.sys_error
+               | "End_of_file" -> Identifier.Constructor.end_of_file
+               | "Division_by_zero" -> Identifier.Constructor.division_by_zero
+               | "Stack_overflow" -> Identifier.Constructor.stack_overflow
+               | "Sys_blocked_io" -> Identifier.Constructor.sys_blocked_io
+               | "Assert_failure" -> Identifier.Constructor.assert_failure
+               | "Undefined_recursive_module" ->
+                 Identifier.Constructor.undefined_recursive_module
+               | name -> raise (Non_builtin name))
+           | Some (Path.Pdot (p, _)) ->
+             Identifier.Constructor.dot loc (module_for_path loc p)
+               constr.cstr_name
+           | _ ->
+             fatal_errorf
+               "Translquote [at %a]: unsupported constructor type detected."
+               Location.print_loc (to_location loc)))
      |> Constructor.ident loc
    with Non_builtin name -> Constructor.of_string loc name)
   |> Constructor.wrap

--- a/testsuite/tests/quotation/build_quotation.ml
+++ b/testsuite/tests/quotation/build_quotation.ml
@@ -31,6 +31,13 @@ end
 module Op : sig val ( + ) : string -> string -> string end
 |}];;
 
+module Exc = struct
+  exception E
+end
+[%%expect {|
+module Exc : sig exception E end
+|}];;
+
 #mark_toplevel_in_quotations;;
 
 (* Tests *)
@@ -669,62 +676,63 @@ Hint: Label "x" is defined outside any quotations.
 
 <[ raise (Match_failure ("foo", 42, 100)) ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Match_failure ("foo", 42, 100))]>
+- : 'a expr = <[Stdlib.raise (Stdlib.Match_failure ("foo", 42, 100))]>
 |}];;
 
 <[ raise Out_of_memory ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Out_of_memory]>
+- : 'a expr = <[Stdlib.raise Stdlib.Out_of_memory]>
 |}];;
 
 <[ raise (Invalid_argument "arg") ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Invalid_argument "arg")]>
+- : 'a expr = <[Stdlib.raise (Stdlib.Invalid_argument "arg")]>
 |}];;
 
 <[ raise (Failure "fail") ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Failure "fail")]>
+- : 'a expr = <[Stdlib.raise (Stdlib.Failure "fail")]>
 |}];;
 
 <[ raise Not_found ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Not_found]>
+- : 'a expr = <[Stdlib.raise Stdlib.Not_found]>
 |}];;
 
 <[ raise (Sys_error "err") ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Sys_error "err")]>
+- : 'a expr = <[Stdlib.raise (Stdlib.Sys_error "err")]>
 |}];;
 
 <[ raise End_of_file ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise End_of_file]>
+- : 'a expr = <[Stdlib.raise Stdlib.End_of_file]>
 |}];;
 
 <[ raise Division_by_zero ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Division_by_zero]>
+- : 'a expr = <[Stdlib.raise Stdlib.Division_by_zero]>
 |}];;
 
 <[ raise Stack_overflow ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Stack_overflow]>
+- : 'a expr = <[Stdlib.raise Stdlib.Stack_overflow]>
 |}];;
 
 <[ raise Sys_blocked_io ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise Sys_blocked_io]>
+- : 'a expr = <[Stdlib.raise Stdlib.Sys_blocked_io]>
 |}];;
 
 <[ raise (Assert_failure ("assert", 42, 100)) ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Assert_failure ("assert", 42, 100))]>
+- : 'a expr = <[Stdlib.raise (Stdlib.Assert_failure ("assert", 42, 100))]>
 |}];;
 
 <[ raise (Undefined_recursive_module ("M", 42, 100)) ]>;;
 [%%expect {|
-- : 'a expr = <[Stdlib.raise (Undefined_recursive_module ("M", 42, 100))]>
+- : 'a expr =
+<[Stdlib.raise (Stdlib.Undefined_recursive_module ("M", 42, 100))]>
 |}];;
 
 <[ let exception E in () ]>;;
@@ -1232,8 +1240,8 @@ Error: Identifier "x" is used at line 1, characters 43-44,
 - : <[bool -> int]> expr =
 <[
   fun x ->
-    match x with | true -> (try Stdlib.raise Exit with  | _ -> 0) | false ->
-      1
+    match x with | true -> (try Stdlib.raise Stdlib.Exit with  | _ -> 0) |
+      false -> 1
 ]>
 |}];;
 
@@ -1590,4 +1598,15 @@ let open Op in
 <[ [( + ) for ( + ) = 1 to 3] ]>;;
 [%%expect {|
 - : <[int list]> expr = <[[ ( + ) for ( + ) = 1 to 3 ]]>
+|}];;
+
+(* Extension constructors/exceptions *)
+exception E;;
+[%%expect {|
+exception E
+|}];;
+
+<[ raise E ]>;;
+[%%expect {|
+- : 'a expr = <[Stdlib.raise (E : exn)]>
 |}];;


### PR DESCRIPTION
Extension constructors and exceptions would previously get translated into lambda in a wrong way, potentially triggering environment errors at eval time and fatal errors at quote construction time.

This PR changes the Translquote logic used for translating constructors inside quotations.